### PR TITLE
Expose setViewport function

### DIFF
--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -105,6 +105,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
       getBaseScreenshotOptions: () => this.baseScreenshotOptions,
       getCurrentVariantKey: () => this.currentVariantKey,
       waitBrowserMetricsStable: () => this.waitBrowserMetricsStable('preEmit'),
+      setViewport: (viewport: Viewport) => this.page.setViewport(viewport),
     };
     Object.entries(exposed).forEach(([k, f]) => this.page.exposeFunction(k, f));
   }

--- a/packages/storycap/src/shared/types.ts
+++ b/packages/storycap/src/shared/types.ts
@@ -70,4 +70,5 @@ export interface Exposed {
   getBaseScreenshotOptions(): StrictScreenshotOptions;
   getCurrentVariantKey(): VariantKey;
   waitBrowserMetricsStable(): Promise<void>;
+  setViewport(vp: Viewport): Promise<void>;
 }


### PR DESCRIPTION
Currently, storycap, when taking screenshots, does not resize the viewport until the point of screenshotting. Hence the initial viewport might be different, which can cause issues. For example, if the viewport is too small, responsive design might hide some text which we are then unable to find. The desired solution is to set the viewport before anything has happened. Hence, we expose the `setViewport` method to do so.