### PR TITLE
Expose package subdirectories

### DIFF
--- a/packages/storycap/package.json
+++ b/packages/storycap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix/storycap",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Storybook addon, Save the screenshot image of your stories! via puppeteer.",
   "engines": {
     "node": ">=14.13"
@@ -13,6 +13,8 @@
       "browser": "./lib-esm/index.js",
       "default": "./lib/index.js"
     },
+    "./lib/client/*": "./lib/client/*",
+    "./lib/shared/*": "./lib/shared/*",
     "./register": "./register.js"
   },
   "sideEffects": [


### PR DESCRIPTION
In our Remix monorepo, we need to be able to access modules under ./lib/client/ and ./lib/types/, but a change upstream prevents us from doing so because they're not listed as package entry points ([example build error](https://app.circleci.com/pipelines/github/remix/remix/98985/workflows/65cc78f3-b98e-4490-9fca-c7b7133be352/jobs/2472813)). In this commit, we expose the files under each of those paths so that our monorepo is happy once again.

See: https://nodejs.org/api/packages.html#package-entry-points